### PR TITLE
Adjustment status fixes

### DIFF
--- a/senseinterface.cpp
+++ b/senseinterface.cpp
@@ -379,7 +379,7 @@ bool cSenseInterface::importAdjData(QDataStream &stream)
                 syslog(LOG_ERR,"flashmemory read, contains wrong versionnumber: flash %s / µC %s\n",
                        qPrintable(qs), qPrintable(sDV));
             }
-            m_nVersionStatus += Adjustment::wrongVERS;
+            m_nVersionStatus |= Adjustment::wrongVERS;
             if (!enable) {
                 return false; // wrong version number
             }
@@ -399,7 +399,7 @@ bool cSenseInterface::importAdjData(QDataStream &stream)
             syslog(LOG_ERR, "flashmemory read, contains wrong serialnumber flash: %s / µC: %s\n",
                    s, qPrintable(sysSerNo));
         }
-        m_nSerialStatus += Adjustment::wrongSNR;
+        m_nSerialStatus |= Adjustment::wrongSNR;
         if (!enable) {
             return false; // wrong serial number
         }

--- a/senseinterface.cpp
+++ b/senseinterface.cpp
@@ -36,6 +36,7 @@ cSenseInterface::cSenseInterface(cMT310S2dServer *server)
 
     // Init with bad defaults so coder's bugs pop up
     m_nVersionStatus = Adjustment::wrongVERS;
+    m_nSerialStatus = Adjustment::wrongSNR;
 
     m_pSCPIInterface = m_pMyServer->getSCPIInterface();
     m_MModeHash["AC"]   = SenseSystem::modeAC;

--- a/senseinterface.cpp
+++ b/senseinterface.cpp
@@ -34,6 +34,9 @@ cSenseInterface::cSenseInterface(cMT310S2dServer *server)
 {
     int i;
 
+    // Init with bad defaults so coder's bugs pop up
+    m_nVersionStatus = Adjustment::wrongVERS;
+
     m_pSCPIInterface = m_pMyServer->getSCPIInterface();
     m_MModeHash["AC"]   = SenseSystem::modeAC;
     m_MModeHash["HF"]   = SenseSystem::modeHF;
@@ -383,6 +386,9 @@ bool cSenseInterface::importAdjData(QDataStream &stream)
         else {
             m_nVersionStatus = 0; // ok
         }
+    }
+    else { // version full match
+        m_nVersionStatus = 0; // ok
     }
 
     stream >> s; // we take the serial number now


### PR DESCRIPTION
Did not send out this in 'usual' time because I was a bit worried about the results on 'my' MT310s2:

In the Gui (takes care on three least significant bits for textual status display)

**Before:**
Not adjusted / Wrong serial number / Wrong version

**After:**
Not adjusted

Thought about this some more and think @plohmer did mention that at least the serial number was correct on that device.

However:
* Uninitialized variables can cause any value
* New result is likely correct (so the test results in commit 'cSenseInterface::getAdjustmentStatus(): rewrite' are not correct

So I think this series is OK - or at least good enough for review. It requires more tests and I hope to get some support from @plohmer