### PR TITLE
Enable notifications on SYSTEM:CLAMP:CHANNEL:CATALOG

### DIFF
--- a/clampinterface.h
+++ b/clampinterface.h
@@ -5,6 +5,7 @@
 #include <QStringList>
 
 #include "scpiconnection.h"
+#include "notificationstring.h"
 
 
 // here we hold the clamps that are hotplugged to the system
@@ -34,6 +35,7 @@ public:
     void actualizeClampStatus();
     void addChannel(QString channel);
     void removeChannel(QString channel);
+    void generateAndNotifyClampChannelList();
 
 protected slots:
     virtual void executeCommand(int cmdCode, cProtonetCommand* protoCmd);
@@ -42,6 +44,7 @@ private:
     cMT310S2dServer *m_pMyServer;
     cATMEL *m_pControler;
     QStringList m_ClampChannelList;
+    cNotificationString notifierClampChannelList;
 
     quint16 m_nClampStatus;
     QHash<int, cClamp*> clampHash;


### PR DESCRIPTION
Since it took me some time to understand let's write down so we will remember
what happens as soon as a client registers an async notification:

* We land in cPCBServer::m_RegisterNotifier.
* If there is a matching SCPI command in m_pSCPIInterface we prepare
  cNotificationData with notString unset
* The SCPI command is executed and it emits notifier(cNotificationString*) that
  is connected to cPCBServer::establishNewNotifier(cNotificationString*)
* cPCBServer::establishNewNotifier(cNotificationString *notifier) connects
  notifier's valueChanged() whith cPCBServer::asyncHandler()
* So as soon as cNotificationString changes cPCBServer::asyncHandler() packs
  things to protobuf and sends out the message

wow

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>